### PR TITLE
Fix issues #6, #12 and #16

### DIFF
--- a/euler.c
+++ b/euler.c
@@ -58,7 +58,7 @@ float q_to_roll(float r, float i, float j, float k)
     return roll;
 }
 
-void q_to_ypr(float r, float i, float j, float k, float *pYaw, float *pPitch, float *pRoll)
+void q_to_ypr(float r, float i, float j, float k, float *pRoll, float *pPitch, float *pYaw)
 {
     // convert to Euler Angles
     float num = 2.0f * i * j - 2.0f * r * k;

--- a/euler.c
+++ b/euler.c
@@ -58,7 +58,7 @@ float q_to_roll(float r, float i, float j, float k)
     return roll;
 }
 
-void q_to_ypr(float r, float i, float j, float k, float *pRoll, float *pPitch, float *pYaw)
+void q_to_ypr(float r, float i, float j, float k, float *pYaw, float *pPitch, float *pRoll)
 {
     // convert to Euler Angles
     float num = 2.0f * i * j - 2.0f * r * k;

--- a/euler.h
+++ b/euler.h
@@ -29,6 +29,6 @@ float q_to_roll(float r, float i, float j, float k);
 
 // Get Yaw, Pitch and Roll from quaternion
 void q_to_ypr(float r, float i, float j, float k,
-              float *pRoll, float *pPitch, float *pYaw);
+              float *pYaw, float *pPitch, float *pRoll);
 
 #endif

--- a/sh2.c
+++ b/sh2.c
@@ -887,9 +887,11 @@ static void getProdIdRx(sh2_t *pSh2, const uint8_t *payload, uint16_t len)
     }
 
     // Complete this operation if there is no storage for more product ids
-    if ((pSh2->opData.getProdIds.pProdIds == 0) ||
-        (pSh2->opData.getProdIds.nextEntry >= pSh2->opData.getProdIds.expectedEntries)) {
-        
+    if (pSh2->opData.getProdIds.pProdIds == 0){
+        opCompleted(pSh2, SH2_OK);
+        return;
+    }
+    if (pSh2->opData.getProdIds.nextEntry >= pSh2->opData.getProdIds.expectedEntries) {
         pSh2->opData.getProdIds.pProdIds->numEntries = pSh2->opData.getProdIds.nextEntry;
         opCompleted(pSh2, SH2_OK);
     }

--- a/shtp.c
+++ b/shtp.c
@@ -198,6 +198,17 @@ static void rxAssemble(shtp_t *pShtp, uint8_t *in, uint16_t len, uint32_t t_us)
     chan = in[2];
     seq = in[3];
 
+    if (chan >= SHTP_MAX_CHANS) {
+        // Invalid channel id.
+        pShtp->rxBadChan++;
+
+        if (pShtp->eventCallback) {
+            pShtp->eventCallback(pShtp->eventCookie, SHTP_BAD_RX_CHAN);
+        }
+        return;
+    }
+
+
     if (seq != pShtp->chan[chan].nextInSeq){
         if (pShtp->eventCallback) {
             pShtp->eventCallback(pShtp->eventCookie,
@@ -209,16 +220,6 @@ static void rxAssemble(shtp_t *pShtp, uint8_t *in, uint16_t len, uint32_t t_us)
         pShtp->rxShortFragments++;
         if (pShtp->eventCallback) {
             pShtp->eventCallback(pShtp->eventCookie, SHTP_SHORT_FRAGMENT);
-        }
-        return;
-    }
-        
-    if (chan >= SHTP_MAX_CHANS) {
-        // Invalid channel id.
-        pShtp->rxBadChan++;
-
-        if (pShtp->eventCallback) {
-            pShtp->eventCallback(pShtp->eventCookie, SHTP_BAD_RX_CHAN);
         }
         return;
     }


### PR DESCRIPTION
- For issue #6 the implemented fix is to check first the condition that could result in a NPDR and complete the operation, returning before the dereference can happen.

- For issue #12, the check for a valid channel number needed to happen before the channel number is used as an index for the channels array, otherwise it could result in a segmentation fault in case of invalid data.

- For issue #16, the parameter order in the header file has been changed to match the source file.